### PR TITLE
Fix markdownlint mistakes

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -2,6 +2,9 @@ language: "en-US"
 reviews:
   collapse_walkthrough: true
   sequence_diagrams: false
+  auto_review:
+    enabled: false
+    drafts: false
   tools:
     # Disable eslint and markdown lint since they are handled separately
     # by the ci.yaml workflow, and coderabbit doesn't know how to eslint

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+LICENSE

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # access-codes-map
+
 Access codes map, rewritten as a monorepo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a configuration file to exclude the LICENSE file from markdown linting.
- **Documentation**
  - Improved README formatting by adding a blank line after the main heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->