### PR TITLE
Display server field errors in submission form

### DIFF
--- a/apps/web/src/components/edit-location-dialog.tsx
+++ b/apps/web/src/components/edit-location-dialog.tsx
@@ -76,10 +76,12 @@ export default function EditLocationDialog() {
       closeDialog();
     } else if (formState.errors) {
       for (const [field, messages] of Object.entries(formState.errors)) {
-        form.setError(field as keyof LocationFormData, {
-          type: "server",
-          message: messages.join(", "),
-        });
+        if (field in form.getValues()) {
+          form.setError(field as keyof LocationFormData, {
+            type: "server",
+            message: messages.join(", "),
+          });
+        }
       }
     }
 

--- a/apps/web/src/components/edit-location-dialog.tsx
+++ b/apps/web/src/components/edit-location-dialog.tsx
@@ -73,16 +73,27 @@ export default function EditLocationDialog() {
 
     if (formState.success) {
       toast.success("Location saved successfully");
-    } else {
-      toast.error(formState.message);
+      closeDialog();
+    } else if (formState.errors) {
+      for (const [field, messages] of Object.entries(formState.errors)) {
+        form.setError(field as keyof LocationFormData, {
+          type: "server",
+          message: messages.join(", "),
+        });
+      }
     }
 
-    closeDialog();
+    if (formState.message && !formState.errors) {
+      // Display general error messages if there are no specific field errors
+      toast.error(formState.message);
+    }
   }, [
     formState.success,
     closeDialog,
     formState.isSubmitted,
     formState.message,
+    formState.errors,
+    form,
   ]);
 
   // This is really dumb, but without it the boolean properties from the switches

--- a/apps/web/src/db/index.ts
+++ b/apps/web/src/db/index.ts
@@ -5,11 +5,19 @@ import * as schema from "./schema/schema";
 
 export const getDatabase = cache(() => {
   const { env } = getCloudflareContext();
+  if (Object.keys(env).length === 0) {
+    throw new Error("Environment variables are missing or empty.");
+  }
   return drizzle(env.ACCESS_CODES_DB, { schema });
 });
 
 // This is the one to use for static routes (i.e. ISR/SSG)
 export const getDatabaseAsync = cache(async () => {
   const { env } = await getCloudflareContext({ async: true });
+
+  if (Object.keys(env).length === 0) {
+    throw new Error("Unable to obtain a Cloudflare context.");
+  }
+
   return drizzle(env.ACCESS_CODES_DB, { schema });
 });


### PR DESCRIPTION
I don't really have a way to test this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the Edit Location dialog, allowing users to view and correct specific field errors without the dialog closing automatically on failure.
  - Enhanced database connection reliability by adding checks for missing or empty environment variables before initializing the connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->