### PR TITLE
Remove loading indicator for map

### DIFF
--- a/apps/web/src/app/map/client-section.tsx
+++ b/apps/web/src/app/map/client-section.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Loading } from "@/components/loading";
 import { LocationsWithUsers } from "@/db/locations";
 import dynamic from "next/dynamic";
 
@@ -10,7 +9,6 @@ export interface ClientSectionProperties {
 
 const LocationsMap = dynamic(() => import("./locations-map"), {
   ssr: false,
-  loading: () => <Loading />,
 });
 
 export default function ClientSection({ locations }: ClientSectionProperties) {


### PR DESCRIPTION
This was really disruptive and unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the loading fallback UI when displaying the map, resulting in no loading indicator while the map is being loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->