### PR TITLE
Replace old site in production

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -67,6 +67,10 @@
           "pattern": "accesscodes-prod.badcasserole.com",
           "custom_domain": true,
         },
+        {
+          "pattern": "accesscodes.badcasserole.com",
+          "custom_domain": true,
+        },
       ],
       "vars": {
         "CLOUDFLARE_DATABASE_ID": "e9eb4ee3-9028-429d-9d77-2c67e1cfb255",

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -74,7 +74,7 @@
       ],
       "vars": {
         "CLOUDFLARE_DATABASE_ID": "e9eb4ee3-9028-429d-9d77-2c67e1cfb255",
-        "APP_BASE_URL": "https://accesscodes-prod.badcasserole.com/",
+        "APP_BASE_URL": "https://accesscodes.badcasserole.com/",
         "AUTH0_DOMAIN": "vatsim-edct.us.auth0.com",
         "AUTH0_AUDIENCE": "https://accesscodes.badcasserole.com/",
       },


### PR DESCRIPTION
Fixes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated production environment configuration to include an additional custom domain: accesscodes.badcasserole.com.
  - Changed the base URL for the production environment to https://accesscodes.badcasserole.com/.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->